### PR TITLE
修复在部分 Windows / 网卡驱动（例如 Killer/Intel AX 系列）上的“NULL pointer access”问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Tips：支持Win10、Win11、Linux，MacOS暂不支持
 
 ## 更新日志
 
+### v1.2.6
+- **[修复]** 在部分 Windows / 网卡驱动（例如 Killer/Intel AX 系列）上的“NULL pointer access”问题。
+
+
 ### v1.2.5
 
 - **[新增]** 支持在破解过程中**暂停**。([#26](https://github.com/baihengaead/wifi-crack-tool/issues/26))

--- a/wifi_crack_tool.py
+++ b/wifi_crack_tool.py
@@ -4,10 +4,12 @@ Author: 白恒aead
 Repositories: https://github.com/baihengaead/wifi-crack-tool
 Version: 1.2.5
 """
-import os,sys,datetime,time,threading,ctypes,json
+import os, sys, datetime, time, threading, ctypes, json
 import platform
+import subprocess
+import re
 
-from pywifi import const,PyWiFi,Profile
+from pywifi import const, PyWiFi, Profile
 from pywifi.iface import Interface
 
 import pyperclip
@@ -17,47 +19,49 @@ from PySide6.QtWidgets import QApplication, QMainWindow, QFileDialog, QWidget, Q
 from PySide6.QtGui import QIcon
 from wifi_crack_tool_gui import Ui_MainWindow
 
+
 class MainWindow(QMainWindow):
-    def __init__(self,mutex):
+    def __init__(self, mutex):
         super().__init__()
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
-        
+
         self.icon_path = ""
         if getattr(sys, 'frozen', False):
-            self.icon_path = os.path.join(sys._MEIPASS, "images/wificrack.ico") # type: ignore
+            self.icon_path = os.path.join(sys._MEIPASS, "images/wificrack.ico")  # type: ignore
         else:
             self.icon_path = "images/wificrack.ico"
-        
-        if PyWiFi().interfaces().__len__() <= 1 and  mutex is None:
-            self.showinfo(title=self.windowTitle(), message='应用程序的另一个实例已经在运行。\n(p.s.你当前的设备只有一个网卡，不支持多开！)')
+
+        if PyWiFi().interfaces().__len__() <= 1 and mutex is None:
+            self.showinfo(title=self.windowTitle(),
+                          message='应用程序的另一个实例已经在运行。\n(p.s.你当前的设备只有一个网卡，不支持多开！)')
             sys.exit()
-        
+
         icon = QIcon()
         icon.addFile(self.icon_path, QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.setWindowIcon(icon)
-        
-        #------------------------- 初始化控件状态 -------------------------------#
+
+        # ------------------------- 初始化控件状态 -------------------------------#
         self.ui.cbo_wifi_name.addItem('——全部——')
-        
-        self.ui.cbo_security_type.addItems(['——自动——','WPA','WPAPSK','WPA2','WPA2PSK','WPA3','WPA3SAE','OPEN'])
+
+        self.ui.cbo_security_type.addItems(['——自动——', 'WPA', 'WPAPSK', 'WPA2', 'WPA2PSK', 'WPA3', 'WPA3SAE', 'OPEN'])
         self.ui.cbo_security_type.setCurrentIndex(0)
         self.set_display_using_pwd_file()
-        
+
         self.ui.cbo_wifi_name.setDisabled(True)
         self.ui.cbo_wnic.setDisabled(True)
         self.ui.btn_refresh_wifi.setDisabled(True)
         self.ui.btn_start.setDisabled(True)
         self.ui.btn_pause_or_resume.setDisabled(True)
         self.ui.btn_stop.setDisabled(True)
-        
+
         self.ui.txt_log_msg_info.setReadOnly(True)
         self.log_end = self.ui.txt_log_msg_info.textCursor().MoveOperation.End
         self.log_color = self.ui.txt_log_msg_info.textColor()
-        #======================================================================#
-        
+        # ======================================================================#
+
         self.tool = WifiCrackTool(self)
-        #---------------------- 绑定事件 ---------------------------#
+        # ---------------------- 绑定事件 ---------------------------#
         self.ui.btn_change_pwd_file.clicked.connect(self.tool.change_pwd_file)
         self.ui.btn_refresh_wifi.clicked.connect(self.tool.refresh_wifi)
         self.ui.btn_start.clicked.connect(self.tool.start)
@@ -65,27 +69,29 @@ class MainWindow(QMainWindow):
         self.ui.btn_stop.clicked.connect(self.tool.stop)
         self.ui.dbl_scan_time.valueChanged.connect(self.tool.change_scan_time)
         self.ui.dbl_connect_time.valueChanged.connect(self.tool.change_connect_time)
-        #===========================================================#
-        
-        #---------------------- 更新GUI的信号对象 -------------------------#
-        self.show_msg = MainWindow.SignThread(self.ui.centralwidget,self.tool.show_msg,str,str)
-        self.clear_msg = MainWindow.SignThread(self.ui.centralwidget,self.tool.clear_msg)
-        self.add_wifi_items = MainWindow.SignThread(self.ui.centralwidget,self.ui.cbo_wifi_name.addItems,list)
-        self.set_wifi_current_index = MainWindow.SignThread(self.ui.centralwidget,self.ui.cbo_wifi_name.setCurrentIndex,int)
-        self.set_control_state = MainWindow.SignThread(self.ui.centralwidget,self.set_control_enabled,bool,QWidget)
-        self.reset_controls_state = MainWindow.SignThread(self.ui.centralwidget,self.tool.reset_controls_state)
-        self.set_controls_running_state = MainWindow.SignThread(self.ui.centralwidget,self.tool.set_controls_running_state)
-        self.show_info = MainWindow.SignThread(self.ui.centralwidget,self.showinfo,str,str)
-        self.show_warning = MainWindow.SignThread(self.ui.centralwidget,self.showwarning,str,str)
-        self.show_error = MainWindow.SignThread(self.ui.centralwidget,self.showerror,str,str)
-        #=================================================================#
-        
-        self.show_msg.send(f"初始化完成！\n","black")
-    
-    def showinfo(self,title:str,message:str):
+        # ===========================================================#
+
+        # ---------------------- 更新GUI的信号对象 -------------------------#
+        self.show_msg = MainWindow.SignThread(self.ui.centralwidget, self.tool.show_msg, str, str)
+        self.clear_msg = MainWindow.SignThread(self.ui.centralwidget, self.tool.clear_msg)
+        self.add_wifi_items = MainWindow.SignThread(self.ui.centralwidget, self.ui.cbo_wifi_name.addItems, list)
+        self.set_wifi_current_index = MainWindow.SignThread(self.ui.centralwidget,
+                                                            self.ui.cbo_wifi_name.setCurrentIndex, int)
+        self.set_control_state = MainWindow.SignThread(self.ui.centralwidget, self.set_control_enabled, bool, QWidget)
+        self.reset_controls_state = MainWindow.SignThread(self.ui.centralwidget, self.tool.reset_controls_state)
+        self.set_controls_running_state = MainWindow.SignThread(self.ui.centralwidget,
+                                                                self.tool.set_controls_running_state)
+        self.show_info = MainWindow.SignThread(self.ui.centralwidget, self.showinfo, str, str)
+        self.show_warning = MainWindow.SignThread(self.ui.centralwidget, self.showwarning, str, str)
+        self.show_error = MainWindow.SignThread(self.ui.centralwidget, self.showerror, str, str)
+        # =================================================================#
+
+        self.show_msg.send(f"初始化完成！\n", "black")
+
+    def showinfo(self, title: str, message: str):
         '''
         显示消息提示框
-        
+
         :title 提示框标题
         :message 提示框文本
         '''
@@ -100,11 +106,11 @@ class MainWindow(QMainWindow):
         msg_box.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
         # 显示消息框
         msg_box.exec()
-    
-    def showwarning(self,title:str,message:str):
+
+    def showwarning(self, title: str, message: str):
         '''
         显示警告提示框
-        
+
         :title 提示框标题
         :message 提示框文本
         '''
@@ -119,11 +125,11 @@ class MainWindow(QMainWindow):
         msg_box.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
         # 显示消息框
         msg_box.exec()
-    
-    def showerror(self,title:str,message:str):
+
+    def showerror(self, title: str, message: str):
         '''
         显示错误提示框
-        
+
         :title 提示框标题
         :message 提示框文本
         '''
@@ -138,14 +144,14 @@ class MainWindow(QMainWindow):
         msg_box.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
         # 显示消息框
         msg_box.exec()
-    
-    def set_display_using_pwd_file(self,filename:str="(无)"):
+
+    def set_display_using_pwd_file(self, filename: str = "(无)"):
         self.ui.lbl_using_pwd_file.setText(f"正在使用密码本：{filename}")
-    
-    def set_control_enabled(self,state:bool,*control:QWidget):
+
+    def set_control_enabled(self, state: bool, *control: QWidget):
         '''
         设置控件启用
-        
+
         :state True->启用，False->禁用
         :control 控件对象
         '''
@@ -154,14 +160,14 @@ class MainWindow(QMainWindow):
                 con.setEnabled(state)
         elif len(control) == 1:
             control[0].setEnabled(state)
-        
+
     class SignThread(QThread):
         """GUI信号线程"""
-    
+
         def __new__(cls, parent: QWidget, func, *types: type):
             cls.__update_date = Signal(*types, name=func.__name__)  # 定义信号(*types)一个信号中可以有一个或多个类型的数据(int,str,list,...)
             return super().__new__(cls)  # 使用父类__new__方法创建SignThread实例对象
-    
+
         def __init__(self, parent: QWidget, func, *types: type):
             """
             GUI信号线程初始化\n
@@ -171,7 +177,7 @@ class MainWindow(QMainWindow):
             """
             super().__init__(parent)  # 初始化父类
             self.__update_date.connect(func)  # 绑定信号与方法
-    
+
         def send(self, *args):
             """
             向GUI线程发送更新信号\n
@@ -180,93 +186,98 @@ class MainWindow(QMainWindow):
             """
             self.__update_date.emit(*args)  # 发送信号元组(type,...)
 
+
 class WifiCrackTool:
-    def __init__(self,win:MainWindow):
+    def __init__(self, win: MainWindow):
         self.win = win
         self.ui = win.ui
-        
-        self.config_dir_path = os.getcwd()+"/config" #配置文件目录路径
+
+        self.config_dir_path = os.getcwd() + "/config"  # 配置文件目录路径
         # 如果不存在config目录，则创建
         if not os.path.exists(self.config_dir_path):
             os.mkdir(self.config_dir_path)
 
-        self.log_dir_path = os.getcwd()+"/log" #日志目录路径
+        self.log_dir_path = os.getcwd() + "/log"  # 日志目录路径
         # 如果不存在log目录，则创建
         if not os.path.exists(self.log_dir_path):
             os.mkdir(self.log_dir_path)
-        
-        self.dict_dir_path = os.getcwd()+"/dict" #字典目录路径
+
+        self.dict_dir_path = os.getcwd() + "/dict"  # 字典目录路径
         # 如果不存在dict目录，则创建
         if not os.path.exists(self.dict_dir_path):
             os.mkdir(self.dict_dir_path)
 
-        self.config_file_path = self.config_dir_path+'/settings.json'
+        self.config_file_path = self.config_dir_path + '/settings.json'
         self.config_settings_data = {
-            'scan_time':8,
-            'connect_time':3,
-            'pwd_txt_path':'passwords.txt'
+            'scan_time': 8,
+            'connect_time': 3,
+            'pwd_txt_path': 'passwords.txt'
         }
         if os.path.exists(self.config_file_path):
-            with open(self.config_file_path, 'r',encoding='utf-8') as config_file:
+            with open(self.config_file_path, 'r', encoding='utf-8') as config_file:
                 self.config_settings_data = json.load(config_file)
                 self.ui.dbl_scan_time.setValue(self.config_settings_data['scan_time'])
                 self.ui.dbl_connect_time.setValue(self.config_settings_data['connect_time'])
         else:
-            with open(self.config_file_path, 'w',encoding='utf-8') as config_file:
+            with open(self.config_file_path, 'w', encoding='utf-8') as config_file:
                 json.dump(self.config_settings_data, config_file, indent=4)
-        
+
         pwd_txt_paths = self.config_settings_data['pwd_txt_path'].split('/')
-        self.pwd_txt_name = pwd_txt_paths[len(pwd_txt_paths)-1]
-        
-        self.pwd_dict_path = self.dict_dir_path+'/pwdict.json'
-        
-        self.pwd_dict_data:list[dict[str,str]] = []
+        self.pwd_txt_name = pwd_txt_paths[len(pwd_txt_paths) - 1]
+
+        self.pwd_dict_path = self.dict_dir_path + '/pwdict.json'
+
+        self.pwd_dict_data: list[dict[str, str]] = []
         if os.path.exists(self.pwd_dict_path):
             # 读取密码字典数据
-            with open(self.pwd_dict_path, 'r',encoding='utf-8') as json_file:
+            with open(self.pwd_dict_path, 'r', encoding='utf-8') as json_file:
                 self.pwd_dict_data = json.load(json_file)
-        
+
         self.crack_pause_condition = threading.Condition()
         self.paused = False
-        
+
         self.run = False
         self.pwd_file_changed = False
-        
+
         # 创建破解对象
         self.crack = self.Crack(self)
-        
+
         # 判断默认密码本是否存在
         if not os.path.exists(self.config_settings_data['pwd_txt_path']):
-            self.win.showwarning(title='警告', message='默认密码本[%s]不存在！\n请选择密码本'%(self.config_settings_data['pwd_txt_path']))
+            self.win.showwarning(title='警告', message='默认密码本[%s]不存在！\n请选择密码本' % (
+            self.config_settings_data['pwd_txt_path']))
             self.config_settings_data['pwd_txt_path'] = ""
             self.change_pwd_file()
         else:
             self.win.set_display_using_pwd_file(self.pwd_txt_name)
-    
+
     # 修改扫描WiFi时间
     def change_scan_time(self):
         self.win.tool.config_settings_data['scan_time'] = self.ui.dbl_scan_time.value()
-    
+
     # 修改连接WiFi时间
     def change_connect_time(self):
         self.win.tool.config_settings_data['connect_time'] = self.ui.dbl_connect_time.value()
-    
+
     # 选择密码本
     def change_pwd_file(self):
         '''选择密码本'''
 
         try:
             default_dir = r"."
-            temp_file_path,_ = QFileDialog.getOpenFileName(self.win, caption=u'选择密码本', dir=(os.path.expanduser(default_dir)), filter="Text files (*.txt)")#;;JSON files (*.json)")
+            temp_file_path, _ = QFileDialog.getOpenFileName(self.win, caption=u'选择密码本',
+                                                            dir=(os.path.expanduser(default_dir)),
+                                                            filter="Text files (*.txt)")  # ;;JSON files (*.json)")
             temp_filepaths = temp_file_path.split('/')
-            temp_filename = temp_filepaths[len(temp_filepaths)-1]
+            temp_filename = temp_filepaths[len(temp_filepaths) - 1]
             temp_filenames = temp_filename.split('.')
-            temp_filetype = temp_filenames[len(temp_filenames)-1]
-            if(temp_filetype==''):
-                self.win.showinfo(title='提示',message='未选择密码本')
+            temp_filetype = temp_filenames[len(temp_filenames) - 1]
+            if (temp_filetype == ''):
+                self.win.showinfo(title='提示', message='未选择密码本')
                 self.pwd_file_changed = False
-            elif(temp_filetype not in ['txt']):#,'json']):
-                self.win.showerror(title='选择密码本',message='密码本类型错误！\n目前仅支持格式为[txt]的密码本\n您选择的密码本格式为['+temp_filetype+']')
+            elif (temp_filetype not in ['txt']):  # ,'json']):
+                self.win.showerror(title='选择密码本',
+                                   message='密码本类型错误！\n目前仅支持格式为[txt]的密码本\n您选择的密码本格式为[' + temp_filetype + ']')
                 self.pwd_file_changed = False
             else:
                 self.config_settings_data['pwd_txt_path'] = temp_file_path
@@ -275,16 +286,18 @@ class WifiCrackTool:
                 self.win.set_display_using_pwd_file(self.pwd_txt_name)
                 self.pwd_file_changed = True
         except Exception as r:
-            self.win.showerror(title='错误警告',message='选择密码本时发生未知错误 %s' %(r))
+            self.win.showerror(title='错误警告', message='选择密码本时发生未知错误 %s' % (r))
 
     # 显示日志消息
-    def show_msg(self,msg:str,color:str="black"):
+    def show_msg(self, msg: str, color: str = "black"):
         '''显示日志消息'''
         dt = datetime.datetime.now()
-        with open(f"{self.log_dir_path}/wifi_crack_log_{dt.strftime('%Y%m%d')}.txt","a",encoding='utf-8') as log:
-            log.write(dt.strftime('%Y-%m-%d %H:%M:%S')+" >> "+msg)#输出日志到本地文件
+        with open(f"{self.log_dir_path}/wifi_crack_log_{dt.strftime('%Y%m%d')}.txt", "a", encoding='utf-8') as log:
+            log.write(dt.strftime('%Y-%m-%d %H:%M:%S') + " >> " + msg)  # 输出日志到本地文件
         self.ui.txt_log_msg_info.moveCursor(self.win.log_end)
-        self.ui.txt_log_msg_info.insertHtml("<span style='color:"+color+";'>"+dt.strftime('%Y-%m-%d %H:%M:%S')+" >> "+msg.replace('\n', '<br/>')+"</span><br/>")
+        self.ui.txt_log_msg_info.insertHtml(
+            "<span style='color:" + color + ";'>" + dt.strftime('%Y-%m-%d %H:%M:%S') + " >> " + msg.replace('\n',
+                                                                                                            '<br/>') + "</span><br/>")
         self.ui.txt_log_msg_info.moveCursor(self.win.log_end)
 
     # 清空日志消息
@@ -311,9 +324,10 @@ class WifiCrackTool:
                 self.paused = False
                 self.crack_pause_condition.notify_all()
         except Exception as r:
-            pass 
-    
-    # 设置所有控件为运行时的状态
+            pass
+
+            # 设置所有控件为运行时的状态
+
     def set_controls_running_state(self):
         '''运行状态'''
         self.ui.cbo_wifi_name.setDisabled(True)
@@ -326,7 +340,7 @@ class WifiCrackTool:
         self.ui.btn_start.setDisabled(True)
         self.ui.btn_pause_or_resume.setEnabled(True)
         self.ui.btn_stop.setEnabled(True)
-    
+
     # 设置所有控件为暂停时的状态
     def set_controls_pausing_state(self):
         '''暂停状态'''
@@ -340,7 +354,7 @@ class WifiCrackTool:
         self.ui.btn_start.setDisabled(True)
         self.ui.btn_pause_or_resume.setEnabled(True)
         self.ui.btn_stop.setEnabled(True)
-    
+
     # 刷新wifi列表
     def refresh_wifi(self):
         try:
@@ -351,18 +365,19 @@ class WifiCrackTool:
             self.ui.btn_start.setDisabled(True)
             self.ui.cbo_wnic.setDisabled(True)
             self.ui.dbl_scan_time.setDisabled(True)
-            thread = threading.Thread(target=self.crack.search_wifi,args=())
+            thread = threading.Thread(target=self.crack.search_wifi, args=())
             thread.daemon = True
             thread.start()
         except Exception as r:
-            self.win.showerror(title='错误警告',message='扫描wifi时发生未知错误 %s' %(r))
-            self.show_msg('[错误]扫描wifi时发生未知错误 %s\n\n' %(r),"red")
+            self.win.showerror(title='错误警告', message='扫描wifi时发生未知错误 %s' % (r))
+            self.show_msg('[错误]扫描wifi时发生未知错误 %s\n\n' % (r), "red")
             self.reset_controls_state()
 
     # 开始破解
     def start(self):
         try:
-            if self.config_settings_data['pwd_txt_path']!="" and os.path.exists(self.config_settings_data['pwd_txt_path']):
+            if self.config_settings_data['pwd_txt_path'] != "" and os.path.exists(
+                    self.config_settings_data['pwd_txt_path']):
                 wifi_name = self.ui.cbo_wifi_name.currentText()
                 self.run = True
                 self.set_controls_running_state()
@@ -371,15 +386,15 @@ class WifiCrackTool:
                     thread.daemon = True
                     thread.start()
                 else:
-                    thread = threading.Thread(target=self.crack.crack,args=(wifi_name,))
+                    thread = threading.Thread(target=self.crack.crack, args=(wifi_name,))
                     thread.daemon = True
                     thread.start()
             else:
                 if self.change_pwd_file():
                     self.start()
         except Exception as r:
-            self.win.showerror(title='错误警告',message='开始运行时发生未知错误 %s' %(r))
-            self.show_msg('[错误]开始运行时发生未知错误 %s\n\n' %(r),"red")
+            self.win.showerror(title='错误警告', message='开始运行时发生未知错误 %s' % (r))
+            self.show_msg('[错误]开始运行时发生未知错误 %s\n\n' % (r), "red")
             self.reset_controls_state()
 
     # 暂停破解
@@ -397,10 +412,10 @@ class WifiCrackTool:
                     self.show_msg("正在尝试暂停破解...")
                     self.crack_pause_condition.notify_all()
         except Exception as r:
-            self.win.showerror(title='错误警告',message='暂停过程中发生未知错误 %s' %(r))
-            self.show_msg('[错误]暂停过程中发生未知错误 %s\n\n' %(r),"red")
+            self.win.showerror(title='错误警告', message='暂停过程中发生未知错误 %s' % (r))
+            self.show_msg('[错误]暂停过程中发生未知错误 %s\n\n' % (r), "red")
             self.reset_controls_state()
-    
+
     # 终止破解
     def stop(self):
         try:
@@ -410,88 +425,253 @@ class WifiCrackTool:
                 self.paused = False
                 self.crack_pause_condition.notify_all()
         except Exception as r:
-            self.win.showerror(title='错误警告',message='停止过程中发生未知错误 %s' %(r))
-            self.show_msg('[错误]停止过程中发生未知错误 %s\n\n' %(r),"red")
+            self.win.showerror(title='错误警告', message='停止过程中发生未知错误 %s' % (r))
+            self.show_msg('[错误]停止过程中发生未知错误 %s\n\n' % (r), "red")
             self.reset_controls_state()
 
     # 暴力破解wifi密码的类
     class Crack:
         '''用于暴力破解wifi的类'''
-        def __init__(self,tool:'WifiCrackTool'):
-            self.tool:WifiCrackTool = tool
+
+        def __init__(self, tool: 'WifiCrackTool'):
+            self.tool: WifiCrackTool = tool
             self.win = tool.win
             self.ui = tool.ui
             self.wifi = PyWiFi()
             self.wnics = self.wifi.interfaces()
-            self.iface:Interface
+            self.iface: Interface
             self.__get_wnic()
             self.ssids = []
             self.profile_dict = {}
             '''wifi信息字典'''
             self.convert_success = False
             self.is_auto = False
-        
+
         def __get_wnic(self):
             '''获取无线网卡'''
             try:
                 if self.wnics.__len__() > 0:
                     self.tool.show_msg(f'已搜索到无线网卡（数量:{self.wnics.__len__()}）\n')
-                    for i,wnic in enumerate(self.wnics):
-                        self.ui.cbo_wnic.addItem(wnic.name(),i)
+                    for i, wnic in enumerate(self.wnics):
+                        self.ui.cbo_wnic.addItem(wnic.name(), i)
                     self.ui.cbo_wnic.setEnabled(True)
                     self.ui.btn_refresh_wifi.setEnabled(True)
                 else:
-                    self.win.showwarning(title='警告',message='无法获取到无线网卡！\n请确保你的电脑拥有无线网卡再继续使用。')
+                    self.win.showwarning(title='警告',
+                                         message='无法获取到无线网卡！\n请确保你的电脑拥有无线网卡再继续使用。')
                     self.tool.show_msg('无法获取到无线网卡！\n请确保你的电脑拥有无线网卡才可继续使用。\n\n')
-                
+
             except Exception as r:
-                self.win.showerror(title='错误警告',message=f'获取无线网卡时发生未知错误 {r}')
-                self.tool.show_msg(f"[错误]获取无线网卡时发生未知错误 {r}\n\n","red")
+                self.win.showerror(title='错误警告', message=f'获取无线网卡时发生未知错误 {r}')
+                self.tool.show_msg(f"[错误]获取无线网卡时发生未知错误 {r}\n\n", "red")
                 self.tool.reset_controls_state()
-                
-        def search_wifi(self):
-            """扫描附近wifi => wifi名称数组"""
+
+        def _get_field(self, data, name, default=None):
+            """
+            安全读取字段：data 可能为 pywifi Profile 对象或 dict
+            """
             try:
-                self.iface = self.wnics[self.ui.cbo_wnic.currentData()]
-                name = self.iface.name()#网卡名称
-                self.iface.scan()#扫描AP
-                self.win.show_msg.send(f"正在使用网卡[{name}]扫描WiFi...\n","black")
-                time.sleep(self.tool.config_settings_data['scan_time']) # 由于不同网卡的扫描时长不同，建议调整合适的延时时间
-                ap_list = self.iface.scan_results()#扫描结果列表
-                
-                # 去除重复AP项
+                if hasattr(data, name):
+                    return getattr(data, name)
+                if isinstance(data, dict):
+                    return data.get(name, default)
+            except Exception:
+                pass
+            return default
+
+        def search_wifi(self):
+            """扫描附近wifi => wifi名称数组（更健壮：pywifi失败时在Windows下回退到 netsh）"""
+            try:
+                # 保险：如果 combobox 没有 userData，回退到第 0 个网卡
+                idx = self.ui.cbo_wnic.currentData()
+                if idx is None:
+                    idx = 0
+
+                self.iface = self.wnics[idx]
+                name = self.iface.name()  # 网卡名称
+
+                # 发起扫描
+                try:
+                    self.iface.scan()
+                    self.win.show_msg.send(f"正在使用网卡[{name}]扫描WiFi...\n", "black")
+                    time.sleep(self.tool.config_settings_data['scan_time'])  # 等待扫描完成
+                except Exception as e:
+                    # 记录但继续尝试获取结果（部分驱动在 scan() 就会失败）
+                    self.win.show_msg.send(
+                        f"[警告]调用 iface.scan() 失败: {e}\n会尝试继续获取结果或回退到系统命令扫描。\n", "orange")
+
+                # 尝试用 pywifi 获取结果
+                ap_list = None
+                try:
+                    ap_list = self.iface.scan_results()
+                except Exception as e:
+                    err_text = str(e)
+                    self.win.show_msg.send(f"[错误]获取扫描结果时发生错误: {err_text}\n\n", "red")
+                    ap_list = None
+
+                # 如果 pywifi 没有返回结果，在 Windows 上回退到 netsh
+                if not ap_list and platform.system() == "Windows":
+                    self.win.show_msg.send("pywifi 未返回扫描结果，尝试使用系统命令 netsh 进行回退扫描...\n", "orange")
+                    ap_list = self._scan_with_netsh()
+                    # _scan_with_netsh 返回的是一个列表，每项为简易对象（只需 .ssid/.auth/.akm/.cipher）
+                    # 转换成和 pywifi.scan_results() 类似的结构（Profile-compatible 字段）
+                    if not ap_list:
+                        self.win.show_msg.send("[错误]netsh 回退也未返回任何 AP 项。\n\n", "red")
+                        self.win.reset_controls_state.send()
+                        return
+                elif not ap_list:
+                    # 非 Windows 或 netsh 也无法工作
+                    status = None
+                    try:
+                        status = self.iface.status()
+                    except Exception:
+                        pass
+
+                    if status in [const.IFACE_DISCONNECTED, const.IFACE_INACTIVE]:
+                        self.win.show_warning.send('警告', '你当前设备的WLAN未打开！请打开WLAN后再继续使用。')
+                        self.win.show_msg.send(
+                            f"[警告]你当前设备的WLAN未打开或驱动/权限问题导致无法扫描，请检查WLAN/驱动/以管理员运行。\n\n",
+                            "orange")
+                    else:
+                        self.win.show_msg.send("[错误]扫描没有返回任何AP项，可能是驱动/权限或接口异常。\n\n", "red")
+
+                    self.win.reset_controls_state.send()
+                    return
+
+                # 如果 ap_list 是 netsh 返回的字典列表，则已准备好；否则按原逻辑处理
+                # 去除重复并忽略空 SSID
                 ap_dic_tmp = {}
                 for b in ap_list:
-                    if b.ssid.replace(' ', '') != '':
-                        ap_dic_tmp[b.ssid] = b
-                
-                # 将字典转换为列表，并去除列表中的空字符项
+                    try:
+                        ssid_val = b.ssid if hasattr(b, 'ssid') else (b.get('ssid', '') if isinstance(b, dict) else '')
+                        ssid_clean = ssid_val.replace(' ', '')
+                    except Exception:
+                        # 遇到底层对象异常（防御性跳过）
+                        continue
+                    if ssid_clean != '':
+                        ap_dic_tmp[ssid_val] = b
+
                 ap_list = list(ap_dic_tmp.values())
-                
-                self.win.show_msg.send("扫描完成！\n","black")
-                self.ssids:list[str] = []
-                self.profile_dict:dict[str,Profile] = {}
-                for i,data in enumerate(ap_list):#输出扫描到的WiFi名称
-                    ssid = data.ssid
-                    self.ssids.insert(i,ssid)
+
+                self.win.show_msg.send("扫描完成！\n", "black")
+                self.ssids = []
+                self.profile_dict = {}
+                for i, data in enumerate(ap_list):
+                    ssid = data.ssid if hasattr(data, 'ssid') else (
+                        data.get('ssid') if isinstance(data, dict) else None)
+                    self.ssids.insert(i, ssid)
                     profile = Profile()
-                    profile.ssid = data.ssid # * wifi名称
-                    profile.auth = data.auth # * 网卡的开放
-                    profile.akm = data.akm # * wifi加密算法，一般是 WPA2PSK
-                    profile.cipher = data.cipher # * 加密单元
-                    self.profile_dict[data.ssid] = profile
+                    # 当使用 netsh 回退时 data 可能是 dict，兼容取值，使用安全读取函数
+                    profile.ssid = ssid
+                    profile.auth = self._get_field(data, 'auth', const.AUTH_ALG_OPEN)
+                    profile.akm = self._get_field(data, 'akm', [])
+                    profile.cipher = self._get_field(data, 'cipher', const.CIPHER_TYPE_CCMP)
+                    self.profile_dict[ssid] = profile
+
                 self.win.reset_controls_state.send()
                 self.win.add_wifi_items.send(self.ssids)
                 if len(self.ssids) > 0:
                     self.win.set_wifi_current_index.send(0)
+
             except Exception as r:
-                if r.args[0] == 'NULL pointer access' and self.iface.status() in [const.IFACE_DISCONNECTED,const.IFACE_INACTIVE]:
-                    self.win.show_warning.send('警告',f'你当前设备的WLAN未打开！请打开WLAN后再继续使用。')
-                    self.win.show_msg.send(f"[警告]你当前设备的WLAN未打开！请打开WLAN后再继续使用。\n\n","orange")
+                # 更宽松的 NULL pointer 判断
+                msg = str(r)
+                if 'NULL pointer' in msg or 'NULL pointer access' in msg:
+                    try:
+                        status = self.iface.status()
+                    except Exception:
+                        status = None
+                    if status in [const.IFACE_DISCONNECTED, const.IFACE_INACTIVE]:
+                        self.win.show_warning.send('警告', '你当前设备的WLAN未打开！请打开WLAN后再继续使用。')
+                        self.win.show_msg.send(f"[警告]你当前设备的WLAN未打开！请打开WLAN后再继续使用。\n\n", "orange")
+                    else:
+                        self.win.show_error.send('错误警告', f'扫描wifi时发生底层空指针错误: {msg}')
+                        self.win.show_msg.send(f"[错误]扫描wifi时发生底层空指针错误 {msg}\n\n", "red")
                 else:
-                    self.win.show_error.send('错误警告',f'扫描wifi时发生未知错误 {r}')
-                    self.win.show_msg.send(f"[错误]扫描wifi时发生未知错误 {r}\n\n","red")
+                    self.win.show_error.send('错误警告', f'扫描wifi时发生未知错误 {r}')
+                    self.win.show_msg.send(f"[错误]扫描wifi时发生未知错误 {r}\n\n", "red")
                 self.win.reset_controls_state.send()
+
+        def _scan_with_netsh(self):
+            """
+            Windows 回退：调用 netsh wlan show networks mode=bssid 并解析输出，
+            返回列表，每项为 dict: {'ssid':..., 'auth':..., 'akm': [...], 'cipher': ...}
+            兼容中文/英文输出，使用 Windows 本地编码(mbcs)解码，并记录 returncode/stdout/stderr 长度以便排查
+            """
+            try:
+                cmd = ["netsh", "wlan", "show", "networks", "mode=bssid"]
+                # 使用 Windows 本地 ANSI 编码(mbcs)并用 replace 避免解码异常
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    encoding='mbcs',
+                    errors='replace',
+                    timeout=12
+                )
+                out = proc.stdout
+                err = proc.stderr
+                # 记录 debug 信息到日志（短信息）
+                try:
+                    self.win.show_msg.send(
+                        f"[debug] netsh returncode={proc.returncode} stdout_len={len(out) if out else 0} stderr_len={len(err) if err else 0}\n",
+                        "black")
+                except Exception:
+                    pass
+
+                # 如果 stdout 为空，尝试使用 stderr 内容作为备选（有时 netsh 的信息会走 stderr）
+                if not out:
+                    out = err or ""
+                if not out:
+                    return []
+
+                networks = []
+                # 支持英文和中文标签，并兼容半角和全角冒号
+                ssid_re = re.compile(r"^\s*SSID\s+\d+\s*[:：]\s*(.*)$", re.IGNORECASE)
+                auth_re = re.compile(r"^\s*(?:Authentication|身份验证)\s*[:：]\s*(.*)$", re.IGNORECASE)
+                cipher_re = re.compile(r"^\s*(?:Encryption|加密)\s*[:：]\s*(.*)$", re.IGNORECASE)
+                current = None
+                for line in out.splitlines():
+                    m = ssid_re.match(line)
+                    if m:
+                        if current:
+                            networks.append(current)
+                        current = {'ssid': m.group(1).strip(), 'auth': None, 'akm': [], 'cipher': None}
+                        continue
+                    if current is None:
+                        continue
+                    m = auth_re.match(line)
+                    if m:
+                        current['auth'] = m.group(1).strip()
+                        continue
+                    m = cipher_re.match(line)
+                    if m:
+                        current['cipher'] = m.group(1).strip()
+                        continue
+                if current:
+                    networks.append(current)
+                # 简单推断 akm（占位），优先根据 auth 字段
+                for n in networks:
+                    auth = n.get('auth', '') or ''
+                    au = auth.upper()
+                    if 'WPA3' in au or 'SAE' in au:
+                        n['akm'] = [const.AKM_TYPE_SAE] if hasattr(const, 'AKM_TYPE_SAE') else []
+                    elif 'WPA2' in au:
+                        n['akm'] = [const.AKM_TYPE_WPA2PSK] if hasattr(const, 'AKM_TYPE_WPA2PSK') else []
+                    elif 'WPA' in au:
+                        n['akm'] = [const.AKM_TYPE_WPA] if hasattr(const, 'AKM_TYPE_WPA') else []
+                    elif 'OPEN' in au or 'NONE' in au or '无' in au:
+                        n['akm'] = [const.AKM_TYPE_NONE] if hasattr(const, 'AKM_TYPE_NONE') else []
+                    else:
+                        n['akm'] = []
+                return networks
+            except Exception as e:
+                try:
+                    self.win.show_msg.send(f"[错误]netsh 扫描失败: {e}\n", "red")
+                except Exception:
+                    pass
+                return []
 
         def auto_crack(self):
             '''
@@ -499,112 +679,113 @@ class WifiCrackTool:
             '''
             try:
                 self.is_auto = True
-                self.win.show_msg.send(f"开始自动破解已扫描到的所有WiFi\n","blue")
+                self.win.show_msg.send(f"开始自动破解已扫描到的所有WiFi\n", "blue")
                 wifi_info = "WiFi列表：\n"
-                for i,ssid in enumerate(self.ssids,1):
-                    wifi_info = wifi_info+f"{('&nbsp;'*40)}({i}){('&nbsp;'*10)}{ssid}\n"
-                self.win.show_msg.send(wifi_info,"blue")
-                
+                for i, ssid in enumerate(self.ssids, 1):
+                    wifi_info = wifi_info + f"{('&nbsp;' * 40)}({i}){('&nbsp;' * 10)}{ssid}\n"
+                self.win.show_msg.send(wifi_info, "blue")
+
                 pwds = {}
                 colors = {}
                 for ssid in self.ssids:
                     pwd = self.crack(ssid)
-                    if isinstance(pwd,str):
+                    if isinstance(pwd, str):
                         pwds[ssid] = pwd
                         colors[ssid] = "green"
                     else:
                         pwds[ssid] = "破解失败"
                         colors[ssid] = "red"
-                
-                self.win.show_msg.send(f"自动破解已完成！\n","blue")
+
+                self.win.show_msg.send(f"自动破解已完成！\n", "blue")
                 crack_result_info = "结果如下：\n"
-                for i,ssid in enumerate(self.ssids,1):
-                    crack_result_info = crack_result_info+f"<span style='color:{colors[ssid]}'>{('&nbsp;'*40)}({i}){('&nbsp;'*10)}{ssid}{('&nbsp;'*10)}{pwds[ssid]}</span>\n"
-                
-                self.win.show_msg.send(crack_result_info,"blue")
-                self.win.show_info.send('自动破解',"自动破解已完成！破解结果已记录到日志中")
-                
+                for i, ssid in enumerate(self.ssids, 1):
+                    crack_result_info = crack_result_info + f"<span style='color:{colors[ssid]}'>{('&nbsp;' * 40)}({i}){('&nbsp;' * 10)}{ssid}{('&nbsp;' * 10)}{pwds[ssid]}</span>\n"
+
+                self.win.show_msg.send(crack_result_info, "blue")
+                self.win.show_info.send('自动破解', "自动破解已完成！破解结果已记录到日志中")
+
                 self.is_auto = False
                 self.win.reset_controls_state.send()
             except Exception as r:
-                self.win.show_error.send('错误警告','自动破解过程中发生未知错误 %s' %(r))
-                self.win.show_msg.send(f"[错误]自动破解过程中发生未知错误 {r}\n\n","red")
+                self.win.show_error.send('错误警告', '自动破解过程中发生未知错误 %s' % (r))
+                self.win.show_msg.send(f"[错误]自动破解过程中发生未知错误 {r}\n\n", "red")
                 self.is_auto = False
                 self.win.reset_controls_state.send()
                 return False
-        
-        def crack(self,ssid:str):
+
+        def crack(self, ssid: str):
             '''
             破解wifi
             :ssid wifi名称
             '''
             try:
                 self.iface.disconnect()  # 断开所有连接
-                self.win.show_msg.send("正在断开现有连接...\n","black")
+                self.win.show_msg.send("正在断开现有连接...\n", "black")
                 time.sleep(1)
                 if self.iface.status() in [const.IFACE_DISCONNECTED, const.IFACE_INACTIVE]:  # 测试是否已经断开网卡连接
-                    self.win.show_msg.send("现有连接断开成功！\n\n","black")
+                    self.win.show_msg.send("现有连接断开成功！\n\n", "black")
                 else:
-                    self.win.show_msg.send("[错误]现有连接断开失败！\n\n","red")
+                    self.win.show_msg.send("[错误]现有连接断开失败！\n\n", "red")
                     return False
-                self.win.show_msg.send(f"正在准备破解WiFi[{ssid}]...\n\n","black")
+                self.win.show_msg.send(f"正在准备破解WiFi[{ssid}]...\n\n", "black")
 
                 if len(self.tool.pwd_dict_data) > 0:
                     pwd_dict_list = [ssids for ssids in self.tool.pwd_dict_data if ssids['ssid'] == ssid]
                     if len(pwd_dict_list) > 0:
-                        self.win.show_msg.send(f"发现密码字典中存在相同SSID：{ssid}，开始尝试破解...\n\n","black")
-                        for i,pwd_dict in enumerate(pwd_dict_list,1):
+                        self.win.show_msg.send(f"发现密码字典中存在相同SSID：{ssid}，开始尝试破解...\n\n", "black")
+                        for i, pwd_dict in enumerate(pwd_dict_list, 1):
                             # * 暂停线程
                             with self.tool.crack_pause_condition:
                                 if self.tool.paused:
-                                    self.win.show_msg.send("破解已暂停.\n","orange")
+                                    self.win.show_msg.send("破解已暂停.\n", "orange")
                                     self.tool.crack_pause_condition.wait()
                             # * 停止线程
-                            if self.tool.run==False:
-                                self.win.show_msg.send("破解已终止.\n","red")
+                            if self.tool.run == False:
+                                self.win.show_msg.send("破解已终止.\n", "red")
                                 self.win.reset_controls_state.send()
                                 return False
                             pwd = pwd_dict['pwd']
-                            result = self.connect(ssid,pwd,'json',i)
+                            result = self.connect(ssid, pwd, 'json', i)
                             if result and not self.is_auto:
-                                self.win.show_info.send('破解成功',"连接成功，密码：%s\n(已复制到剪切板)"%(pwd))
+                                self.win.show_info.send('破解成功', "连接成功，密码：%s\n(已复制到剪切板)" % (pwd))
                                 self.win.reset_controls_state.send()
                                 return True
                             elif result:
                                 return pwd
-                        self.win.show_msg.send(f"已尝试完密码字典中[{ssid}]的所有密码，未成功破解\n\n","red")
-                self.win.show_msg.send(f"开始尝试使用密码本破解WiFi[{ssid}]...\n\n","black")
-                with open(self.tool.config_settings_data['pwd_txt_path'],'r', encoding='utf-8', errors='ignore') as lines:
-                        for i,line in enumerate(lines,1):
-                            # * 暂停线程
-                            with self.tool.crack_pause_condition:
-                                if self.tool.paused:
-                                    self.win.show_msg.send("破解已暂停.\n","orange")
-                                    self.tool.crack_pause_condition.wait()
-                            # * 停止线程
-                            if self.tool.run==False:
-                                self.win.show_msg.send("破解已终止.\n","red")
-                                self.win.reset_controls_state.send()
-                                return False
-                            pwd = line.strip()
-                            result = self.connect(ssid,pwd,'txt',i)
-                            if result and not self.is_auto:
-                                self.win.show_info.send('破解成功',"连接成功，密码：%s\n(已复制到剪切板)"%(pwd))
-                                self.win.reset_controls_state.send()
-                                return True
-                            elif result:
-                                return pwd
-                        if not self.is_auto:
-                            self.win.show_info.send('破解失败',"破解失败，已尝试完密码本中所有可能的密码")
+                        self.win.show_msg.send(f"已尝试完密码字典中[{ssid}]的所有密码，未成功破解\n\n", "red")
+                self.win.show_msg.send(f"开始尝试使用密码本破解WiFi[{ssid}]...\n\n", "black")
+                with open(self.tool.config_settings_data['pwd_txt_path'], 'r', encoding='utf-8',
+                          errors='ignore') as lines:
+                    for i, line in enumerate(lines, 1):
+                        # * 暂停线程
+                        with self.tool.crack_pause_condition:
+                            if self.tool.paused:
+                                self.win.show_msg.send("破解已暂停.\n", "orange")
+                                self.tool.crack_pause_condition.wait()
+                        # * 停止线程
+                        if self.tool.run == False:
+                            self.win.show_msg.send("破解已终止.\n", "red")
                             self.win.reset_controls_state.send()
+                            return False
+                        pwd = line.strip()
+                        result = self.connect(ssid, pwd, 'txt', i)
+                        if result and not self.is_auto:
+                            self.win.show_info.send('破解成功', "连接成功，密码：%s\n(已复制到剪切板)" % (pwd))
+                            self.win.reset_controls_state.send()
+                            return True
+                        elif result:
+                            return pwd
+                    if not self.is_auto:
+                        self.win.show_info.send('破解失败', "破解失败，已尝试完密码本中所有可能的密码")
+                        self.win.reset_controls_state.send()
                 return False
             except Exception as r:
-                self.win.show_error.send('错误警告','破解过程中发生未知错误 %s' %(r))
-                self.win.show_msg.send(f"[错误]破解过程中发生未知错误 {r}\n\n","red")
+                self.win.show_error.send('错误警告', '破解过程中发生未知错误 %s' % (r))
+                self.win.show_msg.send(f"[错误]破解过程中发生未知错误 {r}\n\n", "red")
                 self.win.reset_controls_state.send()
                 return False
-        
-        def connect(self,ssid,pwd,filetype,count):
+
+        def connect(self, ssid, pwd, filetype, count):
             '''
             连接wifi
             :ssid wifi名称
@@ -628,52 +809,56 @@ class WifiCrackTool:
                     akm_v = akm_dict[akm]
                 else:
                     akm_v = const.AKM_TYPE_NONE
-                
+
                 profile = Profile()  # * 创建wifi配置对象
                 if akm_i == 0:
                     profile = self.profile_dict[ssid]
                 else:
-                    profile.ssid = ssid # * wifi名称
+                    profile.ssid = ssid  # * wifi名称
                     profile.auth = const.AUTH_ALG_OPEN  # * 网卡的开放
                     profile.akm = akm_v  # * wifi加密算法，一般是 WPA2PSK
-                    profile.cipher = const.CIPHER_TYPE_CCMP # * 加密单元
-                    
-                profile.key = pwd   # * type: ignore #WiFi密码
+                    profile.cipher = const.CIPHER_TYPE_CCMP  # * 加密单元
+
+                profile.key = pwd  # * type: ignore #WiFi密码
                 self.iface.remove_network_profile(profile)  # * 删除wifi文件
-                tem_profile = self.iface.add_network_profile(profile)   # * 添加新的WiFi文件
-                self.win.show_msg.send(f"正在进行第{count}次尝试...\n","black")
-                self.iface.connect(tem_profile) # * 连接
-                time.sleep(self.tool.config_settings_data['connect_time'])   # * 连接需要时间
-                if self.iface.status() == const.IFACE_CONNECTED:    # * 判断是否连接成功
-                    self.win.show_msg.send(f"连接成功，密码：{pwd}\n\n","green")
-                    pyperclip.copy(pwd); # * 将密码复制到剪切板
+                tem_profile = self.iface.add_network_profile(profile)  # * 添加新的WiFi文件
+                self.win.show_msg.send(f"正在进行第{count}次尝试...\n", "black")
+                self.iface.connect(tem_profile)  # * 连接
+                time.sleep(self.tool.config_settings_data['connect_time'])  # * 连接需要时间
+                if self.iface.status() == const.IFACE_CONNECTED:  # * 判断是否连接成功
+                    self.win.show_msg.send(f"连接成功，密码：{pwd}\n\n", "green")
+                    pyperclip.copy(pwd);  # * 将密码复制到剪切板
                     if filetype != 'json':
-                        self.tool.pwd_dict_data.append({'ssid':ssid,'pwd':pwd})
+                        self.tool.pwd_dict_data.append({'ssid': ssid, 'pwd': pwd})
                         # * 直接将数据写入文件
-                        with open(self.tool.pwd_dict_path, 'w',encoding='utf-8') as json_file:
+                        with open(self.tool.pwd_dict_path, 'w', encoding='utf-8') as json_file:
                             json.dump(self.tool.pwd_dict_data, json_file, indent=4)
                     return True
                 else:
-                    self.win.show_msg.send(f"连接失败，密码是{pwd}\n\n","red")
+                    self.win.show_msg.send(f"连接失败，密码是{pwd}\n\n", "red")
                     self.iface.remove_network_profile(profile)  # * 删除wifi文件
                     return False
 
             except Exception as r:
-                self.win.show_error.send('错误警告','连接wifi过程中发生未知错误 %s' %(r))
-                self.win.show_msg.send(f"[错误]连接wifi过程中发生未知错误 {r}\n\n","red")
+                self.win.show_error.send('错误警告', '连接wifi过程中发生未知错误 %s' % (r))
+                self.win.show_msg.send(f"[错误]连接wifi过程中发生未知错误 {r}\n\n", "red")
                 self.win.reset_controls_state.send()
                 return False
+
 
 if __name__ == "__main__":
     try:
         app = QApplication(sys.argv)
-        
+
         system = platform.system()
         if system == 'Windows':
             print('当前系统是 Windows')
-            import win32api,win32security,win32event # type: ignore
-            #------------------- 互斥锁 -----------------------#
+            import win32api, win32security, win32event  # type: ignore
+
+            # ------------------- 互斥锁 -----------------------#
             MUTEX_NAME = "Global/wifi_crack_tool_mutex"
+
+
             def acquire_mutex():
                 sa = win32security.SECURITY_ATTRIBUTES()
                 sa.bInheritHandle = False  # 确保互斥量句柄不会被继承
@@ -684,54 +869,62 @@ if __name__ == "__main__":
                 elif last_error != 0:
                     raise ctypes.WinError(last_error)
                 return mutex
-            #==================================================#
-            
+
+
+            # ==================================================#
+
             __mutex = None
             if PyWiFi().interfaces().__len__() <= 1:
                 __mutex = acquire_mutex()
-            
+
             window = MainWindow(__mutex)
-            
+
         elif system == 'Linux':
             print('当前系统是 Linux')
             import fcntl
-            #------------------- 互斥锁 -----------------------#
+
+            # ------------------- 互斥锁 -----------------------#
             LOCKFILE = "/tmp/wifi_crack_tool.lock"
+
+
             def acquire_lock():
                 lock = os.open(LOCKFILE, os.O_RDWR | os.O_CREAT)
                 try:
-                    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB) # type: ignore
+                    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)  # type: ignore
                     return lock
                 except IOError:
                     return None
 
+
             def release_lock(lock):
-                fcntl.flock(lock, fcntl.LOCK_UN) # type: ignore
+                fcntl.flock(lock, fcntl.LOCK_UN)  # type: ignore
                 os.close(lock)
                 os.remove(LOCKFILE)
-            #==================================================#
-                        
+
+
+            # ==================================================#
+
             __lock = None
             if PyWiFi().interfaces().__len__() <= 1:
                 __lock = acquire_lock()
-                
+
             window = MainWindow(__lock)
-            
+
         elif system == 'Darwin':  # macOS
             print('当前系统是 macOS, 暂不支持')
             sys.exit()
         else:
             print(f'当前系统为 {system}, 暂不支持')
             sys.exit()
-            
+
         window.show()
         app.exec()
-        
+
         if window.tool.config_settings_data["pwd_txt_path"] == "":
             window.tool.config_settings_data["pwd_txt_path"] = "passwords.txt"
-        with open(window.tool.config_file_path, 'w',encoding='utf-8') as config_file:
+        with open(window.tool.config_file_path, 'w', encoding='utf-8') as config_file:
             json.dump(window.tool.config_settings_data, config_file, indent=4)
-            
+
         sys.exit()
     finally:
         if '__mutex' in vars():


### PR DESCRIPTION
- 问题背景
  在部分 Windows / 网卡驱动（例如 Killer/Intel AX 系列）上，pywifi 的 scan_results() 会抛出 “NULL pointer access”，导致扫描失败或程序异常退出；同时在回退使用 netsh 时会出现编码解码错误（UnicodeDecodeError），并且处理 pywifi Profile 对象与 dict 结果时存在属性访问错误（AttributeError: 'Profile' object has no attribute 'get'）。

- 本次改动（主要实现）
  1. 增强 scan_wifi 的健壮性：
     - 对 iface.scan() 和 iface.scan_results() 增加异常保护，避免底层空指针导致程序崩溃。
  2. Windows 回退到 netsh：
     - 当 pywifi 无法返回扫描结果时，在 Windows 平台自动回退执行 `netsh wlan show networks mode=bssid` 并解析输出以获得 SSID、Authentication、Encryption 等信息。
     - 提供 _scan_with_netsh 函数用于解析 netsh 输出，兼容中文/英文标签并尝试简单推断 akm。
  3. 解决 netsh 编码问题：
     - 调用 subprocess.run 时指定 encoding='mbcs' 和 errors='replace'（Windows 本地编码），并在 stdout 为空时读取 stderr 作为备选，以避免 UnicodeDecodeError。
     - 在日志中写入简短的 debug 行：netsh returncode / stdout_len / stderr_len，便于排查。
  4. 修复 Profile/dict 访问兼容性：
     - 新增 _get_field(data, name, default) 安全读取函数，统一从 pywifi Profile 对象或 dict 中获取字段，避免在参数评估时触发 AttributeError。
  5. 改进日志与 GUI 交互：
     - 在关键错误与回退分支增加友好提示（show_warning/show_error），并在日志中记录详细信息，提示用户以管理员运行或检查 WLAN 服务。
  6. 其他小修复：
     - 在选择网卡索引时做更保险的回退（当 combo 未设置 currentData 时回退到 0）。
     - 在文件顶部新增必要 imports（subprocess、re），并在 _scan_with_netsh 中增强对中文全角冒号等的正则兼容。

- 测试
  - 在 Windows 11（ Killer(R) Wi‑Fi 6E AX1675x网卡）上测试：
    - 复现 pywifi 抛出 NULL pointer 的情形，确认新实现会尝试 netsh 回退并成功列出 SSID。
    - 确认使用 encoding='mbcs' 后不会再出现 UnicodeDecodeError。
    - 确认 Profile 与 dict 兼容读取不再触发 AttributeError。
  - GUI 行为：刷新列表、选择 SSID、开始/暂停/停止 状态切换正常，日志能写入 log/ 文件夹。

- 向维护者的说明与建议
  - 已保留并未更改原项目 LICENSE；请确认许可条款以决定是否合并或以何种方式发布二进制文件。
  - 该补丁采用“优先 pywifi，失败回退 netsh”的策略。若觉得对 Windows 优先使用 netsh 更稳妥，可在后续添加配置项以切换策略。
  - 有关 akm 的推断仅为简化用途，不能保证在所有环境下与 pywifi akm 值一一对应；如需更准确的加密类型匹配，可进一步扩展解析或使用更丰富的 mapping 表。

- 变更文件（主要）
  - wifi_crack_tool.py（完整重构/替换 Crack.search_wifi、_scan_with_netsh、添加 _get_field、改进日志、增加 imports 等）